### PR TITLE
Allow using existing VPC and Subnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ You will also need to generate a EC2 Key Pair in your AWS Console before creatin
 This template is designed to provision the required services in a fresh AWS Account. The following services will be deployed:
 
 * **VPC and Subnets** in the selected region. Valohai will also deploy a Internet Gateway and RouteTables.
+  * You can also specify the IDs of an existing VPC and Subnet that you'd like to deploy the Valohai resources to
 * **Two security groups** for Valohai resources:
   * `valohai-sg-workers` that all the Valohai autoscaled EC2 instances will use.
     * By default it doesn't have ports open. You'll have to open ports to allow for example connecting over SSH to the instances.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ main.yml
 ├── network.yml
 |   └── subnet.yml
 ├── s3bucket.yml
+└── worker-security-group.yml
 └── worker-queue.yml
 ```
 

--- a/main.yml
+++ b/main.yml
@@ -22,12 +22,12 @@ Parameters:
   VpcId:
     Type: String
     Description: OPTIONAL. Provide an existing VPC ID to use with Valohai resources. Leave empty if you want to create a new VPC.
-    Default: ''
+    Default: ""
 
   Subnet:
     Type: String
-    Description: Provide the Subnet ID that should be used for the Valohai Queue instance, if you're using an existing VPC. Leave empty if you want the template to create a new VPC and Subnet.
-    Default: ''
+    Description: OPTIONAL. Provide the Subnet ID that should be used for the Valohai Queue instance, if you're using an existing VPC. Leave empty if you want the template to create a new VPC and Subnet.
+    Default: ""
 
 Conditions:
   CreateVPC: !Equals
@@ -125,7 +125,7 @@ Resources:
           Value: "1"
       TemplateURL: ./s3bucket.yml
 
-  WorkerSG:
+  WorkerSecurityGroup:
     Type: AWS::CloudFormation::Stack
     Properties:
       Parameters:
@@ -145,7 +145,7 @@ Resources:
         QueueAddress: !Ref QueueAddress
         Subnet: !If [CreateVPC, !GetAtt Network.Outputs.Subnet1, !Ref Subnet]
         VPC: !If [CreateVPC, !GetAtt Network.Outputs.VPC, !Ref VpcId]
-        WorkersSecurityGroup: !GetAtt WorkerSG.Outputs.SecurityGroup
+        WorkersSecurityGroup: !GetAtt WorkerSecurityGroup.Outputs.SecurityGroup
       Tags:
         - Key: valohai
           Value: "1"
@@ -171,9 +171,9 @@ Outputs:
     Value: !Ref ValohaiMasterRoleARN
     Description: ValohaiMasterRole ARN
   
-  ValohaiWorkerSG:
-    Value: !GetAtt WorkerSG.Outputs.SecurityGroup
-    Description: ValohaiWorkerSG
+  WorkerSecurityGroup:
+    Value: !GetAtt WorkerSecurityGroup.Outputs.SecurityGroup
+    Description: Valohai Security Group ID
 
   VPC:
     Value: !If [CreateVPC, !GetAtt Network.Outputs.VPC, !Ref VpcId]

--- a/main.yml
+++ b/main.yml
@@ -19,6 +19,21 @@ Parameters:
     Type: String
     Description: Name of the Valohai Master Role used for autoscaling resources.
 
+  VpcId:
+    Type: String
+    Description: OPTIONAL. Provide an existing VPC ID to use with Valohai resources. Leave empty if you want to create a new VPC.
+    Default: ''
+
+  Subnet:
+    Type: String
+    Description: Provide the Subnet ID that should be used for the Valohai Queue instance, if you're using an existing VPC. Leave empty if you want the template to create a new VPC and Subnet.
+    Default: ''
+
+Conditions:
+  CreateVPC: !Equals
+    - !Ref VpcId
+    - ""
+
 Mappings:
   RegionMap:
     af-south-1:
@@ -88,6 +103,7 @@ Mappings:
 Resources: 
   Network:
     Type: AWS::CloudFormation::Stack
+    Condition: CreateVPC
     DeletionPolicy: Delete
     Properties:
       Parameters:
@@ -109,6 +125,16 @@ Resources:
           Value: "1"
       TemplateURL: ./s3bucket.yml
 
+  WorkerSG:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Parameters:
+        VPC: !If [CreateVPC, !GetAtt Network.Outputs.VPC, !Ref VpcId]
+      Tags:
+        - Key: valohai
+          Value: "1"
+      TemplateURL: ./worker-security-group.yml
+
   WorkerQueue:
     Type: AWS::CloudFormation::Stack
     DeletionPolicy: Delete
@@ -117,9 +143,9 @@ Resources:
         ImageId: !FindInMap [ RegionMap, !Ref "AWS::Region", ImageId ]
         KeyPair: !Ref KeyPair
         QueueAddress: !Ref QueueAddress
-        Subnet: !GetAtt Network.Outputs.Subnet1
-        VPC: !GetAtt Network.Outputs.VPC
-        WorkersSecurityGroup: !GetAtt Network.Outputs.SecurityGroup
+        Subnet: !If [CreateVPC, !GetAtt Network.Outputs.Subnet1, !Ref Subnet]
+        VPC: !If [CreateVPC, !GetAtt Network.Outputs.VPC, !Ref VpcId]
+        WorkersSecurityGroup: !GetAtt WorkerSG.Outputs.SecurityGroup
       Tags:
         - Key: valohai
           Value: "1"
@@ -144,7 +170,11 @@ Outputs:
   ValohaiMasterRole:
     Value: !Ref ValohaiMasterRoleARN
     Description: ValohaiMasterRole ARN
+  
+  ValohaiWorkerSG:
+    Value: !GetAtt WorkerSG.Outputs.SecurityGroup
+    Description: ValohaiWorkerSG
 
   VPC:
-    Value: !GetAtt Network.Outputs.VPC
+    Value: !If [CreateVPC, !GetAtt Network.Outputs.VPC, !Ref VpcId]
     Description: VPC ID

--- a/network.yml
+++ b/network.yml
@@ -120,20 +120,7 @@ Resources:
         VPC: !Ref VPC
       TemplateURL: ./subnet.yml
 
-  SecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupName: valohai-sg-workers
-      GroupDescription: Security group for Valohai workers
-      VpcId: !Ref VPC
-      Tags:
-        - Key: Name
-          Value: valohai-sg-workers
-
 Outputs:
-  SecurityGroup:
-    Value: !Ref SecurityGroup
-
   Subnet1:
     Value: !GetAtt Subnet1.Outputs.Subnet
 

--- a/worker-security-group.yml
+++ b/worker-security-group.yml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 
-Description: Basic network for Valohai resources
+Description: Security Group for Valohai Workers
 
 Parameters:
   VPC:

--- a/worker-security-group.yml
+++ b/worker-security-group.yml
@@ -1,0 +1,23 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: Basic network for Valohai resources
+
+Parameters:
+  VPC:
+    Description: VPC ID
+    Type: String
+
+Resources:
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: valohai-sg-workers
+      GroupDescription: Security group for Valohai workers
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: valohai-sg-workers
+
+Outputs:
+  SecurityGroup:
+    Value: !Ref SecurityGroup


### PR DESCRIPTION
* Pass in VPC and Subnet as a string (optional)
* If user passes in VPC value then require also subnet, and skip creating the network stack
* Move worker security group creation to a separate stack (so we still run it, even if we don't create a VPC)